### PR TITLE
Add do_shutdown and simple do_history

### DIFF
--- a/bash_kernel.py
+++ b/bash_kernel.py
@@ -102,6 +102,20 @@ class BashKernel(Kernel):
                 'cursor_end': cursor_pos, 'metadata': dict(),
                 'status': 'ok'}
 
+    def do_shutdown(self, restart):
+        if restart:
+            self._start_bash()
+        return {'status': 'ok', 'restart': restart}
+
+    def do_history(self, hist_access_type, output, raw, session=None,
+                   start=None, stop=None, n=None, pattern=None, unique=False):
+        """Access bash history file.
+        """
+        history = self.bashwrapper.run_command('history')
+        history = history.splitlines()
+        history = [(None, None, h) for h in history]
+        return {'history': history}
+
 if __name__ == '__main__':
     from IPython.kernel.zmq.kernelapp import IPKernelApp
     IPKernelApp.launch_instance(kernel_class=BashKernel)


### PR DESCRIPTION
Bash is already shut down at exit, but this adds a `do_shutdown` for a restart.  

`do_history`  uses the bash `history` command to fetch the history.  In my tests `do_history` was only called at startup.
