### PR TITLE
A proposal for a quick fix to issue #15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ import sys
 kernel_json = {"argv":[sys.executable,"-m","bash_kernel", "-f", "{connection_file}"],
  "display_name":"Bash",
  "language":"bash",
- "codemirror_mode":"shell"
+ "codemirror_mode":"shell",
+ "env":{"PS1": "$"}
 }
 
 class install_with_kernelspec(install):


### PR DESCRIPTION
Bash prompt must end by $ for the kernel to work properly.
Like this, you create a new prompt for the bash that will be launched by ipython :)