### PR TITLE
Add tab completion for variables and fix installing in virtualenv.

### DIFF
--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -143,7 +143,7 @@ class BashKernel(Kernel):
             return default
         matches = [m for m in matches if m.startswith(token)]
 
-        return {'matches': matches, 'cursor_start': start,
+        return {'matches': sorted(matches), 'cursor_start': start,
                 'cursor_end': cursor_pos, 'metadata': dict(),
                 'status': 'ok'}
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ class install_with_kernelspec(install):
         install.run(self)
 
         # Now write the kernelspec
+        user = '--user' in sys.argv
         from IPython.kernel.kernelspec import install_kernel_spec
         from IPython.utils.tempdir import TemporaryDirectory
         with TemporaryDirectory() as td:
@@ -27,7 +28,10 @@ class install_with_kernelspec(install):
             # TODO: Copy resources once they're specified
 
             log.info('Installing IPython kernel spec')
-            install_kernel_spec(td, 'bash', user=self.user, replace=True)
+            try:
+                install_kernel_spec(td, "bash", user=user, replace=True)
+            except:
+                install_kernel_spec(td, "bash", user=not user, replace=True)
 
 with open('README.rst') as f:
     readme = f.read()


### PR DESCRIPTION
I implemented tab completion for variables. E.g. $H<tab>.

Completions are sorted alphabetically now.

When in a virtuelenv, setup.py tried to install kernel to /usr/local/share/jupyter instead of corresponding directory in virtualenv. I fixed this like they do in matlab_kernel:
https://github.com/Calysto/matlab_kernel/blob/master/setup.py#L26

Cheers,
Markus