### PR TITLE
Global install possible as root

### DIFF
--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -23,12 +23,11 @@ def install_my_kernel_spec(user=True):
         install_kernel_spec(td, 'bash', user=user, replace=True)
 
 def _is_root():
-    """Cross-platform way to check admin rights"""
     import ctypes, os
     try:
         return os.geteuid() == 0
     except AttributeError:
-        return ctypes.windll.shell32.IsUserAnAdmin() != 0
+        return False # assume not an admin on non-Unix platforms
 
 def main(argv=[]):
     user = '--user' in argv or not _is_root()

--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -23,7 +23,7 @@ def install_my_kernel_spec(user=True):
         install_kernel_spec(td, 'bash', user=user, replace=True)
 
 def _is_root():
-    import ctypes, os
+    import os
     try:
         return os.geteuid() == 0
     except AttributeError:

--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -23,7 +23,6 @@ def install_my_kernel_spec(user=True):
         install_kernel_spec(td, 'bash', user=user, replace=True)
 
 def _is_root():
-    import os
     try:
         return os.geteuid() == 0
     except AttributeError:

--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -22,6 +22,14 @@ def install_my_kernel_spec(user=True):
         print('Installing IPython kernel spec')
         install_kernel_spec(td, 'bash', user=user, replace=True)
 
+def _is_root():
+    """Cross-platform way to check admin rights"""
+    import ctypes, os
+    try:
+        return os.geteuid() == 0
+    except AttributeError:
+        return ctypes.windll.shell32.IsUserAnAdmin() != 0
+
 def main(argv=None):
     install_my_kernel_spec()
 

--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -30,8 +30,9 @@ def _is_root():
     except AttributeError:
         return ctypes.windll.shell32.IsUserAnAdmin() != 0
 
-def main(argv=None):
-    install_my_kernel_spec()
+def main(argv=[]):
+    user = '--user' in argv or not _is_root()
+    install_my_kernel_spec(user=user)
 
 if __name__ == '__main__':
-    main()
+    main(argv=sys.argv)


### PR DESCRIPTION
Changed the default install behavior for root user to be user=False (system path).  Otherwise, root may use the new `--user` option to install to his home directory.

jupyter/docker-stacks#25
