### PR TITLE
Remove warnings imports from jupyter 4

### DIFF
--- a/bash_kernel/__main__.py
+++ b/bash_kernel/__main__.py
@@ -1,3 +1,3 @@
-from IPython.kernel.zmq.kernelapp import IPKernelApp
+from ipykernel.kernelapp import IPKernelApp
 from .kernel import BashKernel
 IPKernelApp.launch_instance(kernel_class=BashKernel)

--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from IPython.kernel.kernelspec import install_kernel_spec
+from jupyter_client.kernelspec import install_kernel_spec
 from IPython.utils.tempdir import TemporaryDirectory
 
 kernel_json = {"argv":[sys.executable,"-m","bash_kernel", "-f", "{connection_file}"],

--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -1,4 +1,4 @@
-from IPython.kernel.zmq.kernelbase import Kernel
+from ipykernel.kernelbase import Kernel
 from pexpect import replwrap, EOF
 
 from subprocess import check_output


### PR DESCRIPTION
I don't guess you want remove the warning now — for reasons with backward compatibility — but apparently this a simple way to remove him.

Sorry for anything, i only try to help.

I really like the existence of bash kernel for jupyter, it's help my docs examples. 

Thanks.

Update: On `ipython notebook` feedback I still trying receive the warning when using bash_kernel (on the exactly momento) but i don't see more the deprecated imports on the module.

![image](https://cloud.githubusercontent.com/assets/7642878/10464775/d6e6d1c4-71c1-11e5-9828-1f4091ec13d0.png)
