### PR TITLE
Incremental output

### DIFF
--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -83,10 +83,19 @@ class BashKernel(Kernel):
         try:
             # Use IREPLWrapper, a subclass of REPLWrapper that gives
             # incremental output specifically for bash_kernel.
+
+            # Note: the next few lines mirror functionality in the
+            # bash() function of pexpect/replwrap.py.  Look at the
+            # source code there for comments and context for
+            # understanding the code here.
             bashrc = os.path.join(os.path.dirname(pexpect.__file__), 'bashrc.sh')
             child = pexpect.spawn("bash", ['--rcfile', bashrc], echo=False,
                                   encoding='utf-8')
-            self.bashwrapper = IREPLWrapper(child, u'\$', u"PS1='{0}' PS2='{1}' PROMPT_COMMAND=''",
+            ps1 = replwrap.PEXPECT_PROMPT[:5] + u'\[\]' + replwrap.PEXPECT_PROMPT[5:]
+            ps2 = replwrap.PEXPECT_CONTINUATION_PROMPT[:5] + u'\[\]' + replwrap.PEXPECT_CONTINUATION_PROMPT[5:]
+            prompt_change = u"PS1='{0}' PS2='{1}' PROMPT_COMMAND=''".format(ps1, ps2)
+            
+            self.bashwrapper = IREPLWrapper(child, u'\$', prompt_change,
                                             extra_init_cmd="export PAGER=cat", bkernel=self)
         finally:
             signal.signal(signal.SIGINT, sig)

--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -149,11 +149,11 @@ class BashKernel(Kernel):
             interrupted = True
             self.bashwrapper._expect_prompt()
             output = self.bashwrapper.child.before
+            self.process_output(output)
         except EOF:
             output = self.bashwrapper.child.before + 'Restarting Bash'
             self._start_bash()
-
-        self.process_output(output)
+            self.process_output(output)
 
         if interrupted:
             return {'status': 'abort', 'execution_count': self.execution_count}

--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -19,7 +19,6 @@ from .images import (
     extract_image_filenames, display_data_for_image, image_setup_cmd
 )
 
-# This subclass for incremental output requires Pexpect 4.
 class IREPLWrapper(replwrap.REPLWrapper):
     def __init__(self, cmd_or_spawn, orig_prompt, prompt_change,
                  extra_init_cmd=None, bkernel=None):

--- a/flit.ini
+++ b/flit.ini
@@ -3,7 +3,7 @@ module = bash_kernel
 author = Thomas Kluyver
 author-email = thomas@kluyver.me.uk
 home-page = https://github.com/takluyver/bash_kernel
-requires = pexpect (>=3.3)
+requires = pexpect (>=4.0)
 description-file = README.rst
 classifiers = Framework :: IPython
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
This addresses issue https://github.com/takluyver/bash_kernel/issues/36.

Seems to work OK with the Jupyter environment provided by "conda install jupyter", before and after updating to Pexpect 4 using "conda uninstall pexpect" and "pip install pexpect". The image display still works with behavior that is a little bit different.  Before, all images were displayed at the end.  Now they are displayed mixed in with the text output.
