### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_packages
+
+import bash_kernel
+
+DESCRIPTION = bash_kernel.__doc__
+VERSION = bash_kernel.__version__
+
+setup(
+    name='bash_kernel',
+    version=VERSION,
+    packages=find_packages(),
+
+    author='Thomas Kluyver',
+    author_email='thomas@kluyver.me.uk',
+    description=DESCRIPTION,
+    license='BSD',
+    url='https://github.com/takluyver/bash_kernel',
+    long_description=open("README.rst").read(),
+    install_requires=["pexpect>=3.3"],
+    classifiers=[
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3",
+        "Topic :: System :: Shells"
+    ]
+)


### PR DESCRIPTION
At our organization, we love ``bash_kernel`` and want to use it on our
supercomputing node. But because of the way the repository is set up, there's
not an automated way for us to automatically build the sources as an install
file. To make matters worse, our firewall configuration doesn't let us download
the package directly from PyPI.

For that reason I've translated ``flit.ini`` into ``setup.py``. If you pull
this commit users with similar environments - including us - can follow along
the repository and deploy releases in an automated fashion without having to
access PyPI directly or copy files by hand. Version numbers, etc. are pulled
out of the package, so no further maintenance should be required.