### PR TITLE
Fixup the install process

### DIFF
--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -3,7 +3,7 @@ import os
 import sys
 import getopt
 
-from jupyter_client.kernelspec import install_kernel_spec
+from jupyter_client.kernelspec import KernelSpecManager
 from IPython.utils.tempdir import TemporaryDirectory
 
 kernel_json = {"argv":[sys.executable,"-m","bash_kernel", "-f", "{connection_file}"],
@@ -21,7 +21,7 @@ def install_my_kernel_spec(user=True, prefix=None):
         # TODO: Copy resources once they're specified
 
         print('Installing IPython kernel spec')
-        install_kernel_spec(td, 'bash', user=user, replace=True, prefix=prefix)
+        KernelSpecManager().install_kernel_spec(td, 'bash', user=user, replace=True, prefix=prefix)
 
 def _is_root():
     try:
@@ -33,7 +33,7 @@ def main(argv=[]):
     prefix = None
     user = not _is_root()
 
-    opts, _ = getopt.getopt(args, '', ['--user', '--prefix='])
+    opts, _ = getopt.getopt(argv[1:], '', ['user', 'prefix='])
     for k, v in opts:
         if k == '--user':
             user = True


### PR DESCRIPTION
Followup on #48. It was presumptuous of me to think my code would be
perfect without running it.

This actually makes the install work and was tested manually. Fixes:

* typos
* getopt was used wrongly
* install_kernel_spec() is missing the prefix argument
See https://github.com/jupyter/jupyter_client/blob/76b0e3f90bdedbe9c04dedbccbb2ea15e9964628/jupyter_client/kernelspec.py#L292-L294