### PR TITLE
fixes type issue takluyver/bash_kernel#57

### DIFF
--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -40,7 +40,7 @@ class IREPLWrapper(replwrap.REPLWrapper):
             # "None" means we are executing code from a Jupyter cell by way of the run_command
             # in the do_execute() code below, so do incremental output.
             while True:
-                pos = self.child.expect_exact([self.prompt, self.continuation_prompt, '\r\n'],
+                pos = self.child.expect_exact([self.prompt, self.continuation_prompt, u'\r\n'],
                                               timeout=None)
                 if pos == 2:
                     # End of line received


### PR DESCRIPTION
Simple fix for takluyver/bash_kernel#57 that generates:

`TypeError: got <type 'str'> ('\r\n') as pattern, must be one of: <type 'unicode'>, pexpect.EOF, pexpect.TIMEOUT`