### PR TITLE
Remove deprecated "replace" option to install kernel

### DIFF
--- a/bash_kernel/install.py
+++ b/bash_kernel/install.py
@@ -21,7 +21,7 @@ def install_my_kernel_spec(user=True, prefix=None):
         # TODO: Copy resources once they're specified
 
         print('Installing IPython kernel spec')
-        KernelSpecManager().install_kernel_spec(td, 'bash', user=user, replace=True, prefix=prefix)
+        KernelSpecManager().install_kernel_spec(td, 'bash', user=user, prefix=prefix)
 
 def _is_root():
     try:


### PR DESCRIPTION
After running `python -m bash_kernel.install` with Python 3.7.0, I got this deprecation notice:

```
Installing IPython kernel spec
/usr/local/lib/python3.7/site-packages/bash_kernel/install.py:24: DeprecationWarning: replace is ignored. Installing a kernelspec always replaces an existing installation
  KernelSpecManager().install_kernel_spec(td, 'bash', user=user, replace=True, prefix=prefix)
```

This PR addresses that notice and removes the ignored replace flag. 