### PR TITLE
Bash kernel on binder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+... image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/takluyver/bash_kernel/master
+
 A Jupyter kernel for bash
 
 This requires IPython 3.

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+# Install the bash kernel
+python -m bash_kernel.install

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,1 @@
+bash_kernel


### PR DESCRIPTION
Hello @takluyver ,

Thank you for the Bash Kernel, I find it so useful to share or demo bash scripts!

Would you like to provide a link to a binder with the bash_kernel? This is what this PR does.

The link in the README will work only once this PR is merged. Meanwhile you can test it at
https://mybinder.org/v2/gh/mwouts/bash_kernel/bash_kernel_on_binder

If you like we could also think of
- documenting how to do this in the README
- adding `jupytext` to `binder/requirements.txt` to allow Jupyter to open `.sh` files as Bash notebooks

Let me know what you think,

Marc