### PR TITLE
Change image text detection from .startsWith to in

### DIFF
--- a/bash_kernel/images.py
+++ b/bash_kernel/images.py
@@ -38,7 +38,7 @@ def extract_image_filenames(output):
     image_filenames = []
 
     for line in output.split("\n"):
-        if line.startswith(_TEXT_SAVED_IMAGE):
+        if _TEXT_SAVED_IMAGE in line:
             filename = line.rstrip().split(": ")[-1]
             image_filenames.append(filename)
         else:


### PR DESCRIPTION
First and foremost: Thank you for all your work on this amazing project.

I have had just a small problem with it:
For a significant amount of time, I was unable to get the `display` function to work. After quite a bit of digging around, I found out that my bash (or maybe ipython) is adding some escape sequences before it, which meant that the searched string was not the actual beginning of the line even if it look like it.

To fix this problem and others like it, I propose to switch from searching the text necessarily at the beginning of the line to searching the text somewhere in the line.

I hope this helps. Thank you again, your work has otherwise been amazing.
Kind regards,
atopion