### PR TITLE
Fixes for modern readline

### DIFF
--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -107,8 +107,6 @@ class BashKernel(Kernel):
 
         # Disable bracketed paste (see <https://github.com/takluyver/bash_kernel/issues/117>)
         self.bashwrapper.run_command("bind 'set enable-bracketed-paste off' >/dev/null 2>&1 || true")
-        # Set TERM_PROGRAM and TERM_PROGAM_VERSION. See <https://github.com/takluyver/bash_kernel/issues/117#issuecomment-1032738154>
-        self.bashwrapper.run_command(f"export TERM_PROGRAM='jupyter_bash_kernel'; export TERM_PROGRAM_VERSION='{__version__}';")
         # Register Bash function to write image data to temporary file
         self.bashwrapper.run_command(image_setup_cmd)
 

--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -107,6 +107,10 @@ class BashKernel(Kernel):
 
         # Register Bash function to write image data to temporary file
         self.bashwrapper.run_command(image_setup_cmd)
+        # Set TERM_PROGRAM and TERM_PROGAM_VERSION. See https://github.com/takluyver/bash_kernel/issues/117#issuecomment-1032738154
+        self.bashwrapper.run_command(f"export TERM_PROGRAM='jupyter_bash_kernel'; export TERM_PROGRAM_VERSION='{__version__}';")
+        # Disable bracketed paste (see https://github.com/takluyver/bash_kernel/issues/117)
+        self.bashwrapper.run_command("(bind 'set enable-bracketed-paste off' || true) >/dev/null 2>&1")
 
     def process_output(self, output):
         if not self.silent:

--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -105,12 +105,13 @@ class BashKernel(Kernel):
         finally:
             signal.signal(signal.SIGINT, sig)
 
+        # Disable bracketed paste (see <https://github.com/takluyver/bash_kernel/issues/117>)
+        self.bashwrapper.run_command("bind 'set enable-bracketed-paste off' >/dev/null 2>&1 || true")
+        # Set TERM_PROGRAM and TERM_PROGAM_VERSION. See <https://github.com/takluyver/bash_kernel/issues/117#issuecomment-1032738154>
+        self.bashwrapper.run_command(f"export TERM_PROGRAM='jupyter_bash_kernel'; export TERM_PROGRAM_VERSION='{__version__}';")
         # Register Bash function to write image data to temporary file
         self.bashwrapper.run_command(image_setup_cmd)
-        # Set TERM_PROGRAM and TERM_PROGAM_VERSION. See https://github.com/takluyver/bash_kernel/issues/117#issuecomment-1032738154
-        self.bashwrapper.run_command(f"export TERM_PROGRAM='jupyter_bash_kernel'; export TERM_PROGRAM_VERSION='{__version__}';")
-        # Disable bracketed paste (see https://github.com/takluyver/bash_kernel/issues/117)
-        self.bashwrapper.run_command("(bind 'set enable-bracketed-paste off' || true) >/dev/null 2>&1")
+
 
     def process_output(self, output):
         if not self.silent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module = "bash_kernel"
 author = "Thomas Kluyver"
 author-email = "thomas@kluyver.me.uk"
 home-page = "https://github.com/takluyver/bash_kernel"
-requires = ["pexpect (>=4.0)"]
+requires = ["pexpect (>=4.0)", "ipykernel"]
 description-file = "README.rst"
 classifiers = [
     "Framework :: IPython",


### PR DESCRIPTION
This will automatically disable bracketed paste, which seems to break bash_kernel. I have verified that this fixes the problem with the latest released version of bash_kernel.

It should address issues described in #117, #116, & #115 (which are all the same AFAICT).

~~Additionally, I've added code to set the TERM_PROGRAM and TERM_PROGRAM_VERSION env vars so others can use this to perform customisation of bashrc as needed. This *might* not be ideal, as perhaps bashrc has executed before these are set. Please advise if that's the case.~~ (removed this)

### To use this code:
```
python3 -m pip uninstall bash_kernel
python3 -m pip install -U git+https://github.com/kdm9/bash_kernel.git@patch-1
```