### PR TITLE
More thoughtful completion

### DIFF
--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -214,7 +214,7 @@ class BashKernel(Kernel):
         # like var="/etc/<tab>", which should complete from /etc/.
         # Let's just hope no one makes a habit of puting =/"/' into file names
         # </naievity>  (blame @kdm9 if it breaks)
-        tokens = re.split("[\t \n;=\"']+", code)
+        tokens = re.split("[\t \n;=\"'><]+", code)
         token = tokens[-1]
         start = cursor_pos - len(token)
         if token and token[0] == '$':

--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -207,18 +207,17 @@ class BashKernel(Kernel):
                    'cursor_end': cursor_pos, 'metadata': dict(),
                    'status': 'ok'}
 
-        if not code or code[-1] == ' ':
-            return default
-
-        tokens = code.replace(';', ' ').split()
-        if not tokens:
-            return default
 
         matches = []
+        # The regex below might cause issues, but is designed to allow
+        # completion on the rhs of a variable assignment and within strings,
+        # like var="/etc/<tab>", which should complete from /etc/.
+        # Let's just hope no one makes a habit of puting =/"/' into file names
+        # </naievity>  (blame @kdm9 if it breaks)
+        tokens = re.split("[\t \n;=\"']+", code)
         token = tokens[-1]
         start = cursor_pos - len(token)
-
-        if token[0] == '$':
+        if token and token[0] == '$':
             # complete variables
             cmd = 'compgen -A arrayvar -A export -A variable %s' % token[1:] # strip leading $
             output = self.bashwrapper.run_command(cmd).rstrip()
@@ -226,10 +225,32 @@ class BashKernel(Kernel):
             # append matches including leading $
             matches.extend(['$'+c for c in completions])
         else:
-            # complete functions and builtins
-            cmd = 'compgen -cdfa %s' % token
+            # complete path 
+            cmd = 'compgen -d -S / %s' % token
             output = self.bashwrapper.run_command(cmd).rstrip()
-            matches.extend(output.split())
+            dirs = list(set(output.split()))
+            cmd = 'compgen -f %s' % token
+            output = self.bashwrapper.run_command(cmd).rstrip()
+            filesanddirs = list(set(output.split()))
+            files = [x for x in filesanddirs if x + "/" not in dirs]
+            if '/' not in token:
+                # Add an explict ./ for relative paths
+                matches.extend(["./" + x for x in files + dirs])
+            else:
+                matches.extend(files)
+                matches.extend(dirs)
+        if '/' not in token and code[-1] != '"':
+            # complete anything command-like (avoid annoying errors where command names get completed after a directory)
+            cmd = 'compgen -abc -A function %s' % token
+            output = self.bashwrapper.run_command(cmd).rstrip()
+            matches.extend(list(set(output.split())))
+        if code[-1] == '"':
+            # complete variables
+            cmd = 'compgen -A arrayvar -A export -A variable %s' % token[1:] # strip leading $
+            output = self.bashwrapper.run_command(cmd).rstrip()
+            completions = set(output.split())
+            # append matches including leading $
+            matches.extend(['$'+c for c in completions])
 
         if not matches:
             return default


### PR DESCRIPTION
A variety of improvements to bash_kernel's completion, all of which try to more semantically match what the user (read: @kdm9) expects when completing from a given position. In particular:

- not completing command names while in something that looks like a path (e.g. `./path/ap<tab>` shouldn't complete the command named `apt`, only the path named `./path/apple.txt`).
- Splitting completion prompts at `=` and `"`, so that one can e.g. complete the path in `variable="./path<tab>"`.

As with all code that tries to be smart, this will likely have a few undesirable corner cases. Please report any issues you encounter!

Making this in a PR so @takluyver has a chance to review/veto it before it it hits `main`. 

**Dear users: if you want to test this now, please install from my dev branch that contains this and the other concurrent PR:**

```
pip uninstall bash_kernel
pip install git+https://github.com/takluyver/bash_kernel.git@kdm9dev
# if you didn't already do this in your conda env/venv/user install, you need to install the kernelspec too:
#python3 -m bash_kernel.install
```