### PR TITLE
Add support for special commands

### DIFF
--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -19,7 +19,7 @@ from .display import (extract_contents, build_cmds)
 
 # Special command patterns
 su = re.compile("(sudo )? *((\/usr)?\/bin\/)?su( +|$).*")
-env = re.compile("(sudo )? *((\/usr)?\/bin\/)?(chroot |env )(.* )?((\/usr)?\/bin\/)?bash( +|$).*")
+env = re.compile("(sudo )? *((\/usr)?\/bin\/)?(chroot |env |exec )(.* )?((\/usr)?\/bin\/)?bash( +|$).*")
 bash = re.compile("(sudo )? *((\/usr)?\/bin\/)?bash( +|$).*")
 passwd = re.compile("(sudo )? *((\/usr)?\/bin\/)?passwd( +|$).*")
 sudo = re.compile("sudo .+")

--- a/bash_kernel/kernel.py
+++ b/bash_kernel/kernel.py
@@ -94,10 +94,6 @@ class IREPLWrapper(replwrap.REPLWrapper):
         # Send code
         self.child.sendline(code)
 
-        # If there is not need to wait for the password prompt
-        if bash.match(code) and not sudo.match(code):
-            self.child.sendline(self.prompt_change)
-
         prompts = [self.ps1_re, self.ps2_re,
                    u"Password", u"\[sudo\] password for ",
                    u"New password",


### PR DESCRIPTION
This pull request adds support for su, sudo, bash, env .. bash, chroot .. bash and passwd commands.

This feature would be disabled by default and can be enabled by the user defining the BASH_KERNEL_SPECIAL_COMMANDS environment variable in the session where the jupyter server is started. 