### PR TITLE
replace deprecated stdlib imghdr with filetype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 build/
 dist/
 MANIFEST
+.ipynb_checkpoints

--- a/bash_kernel/display.py
+++ b/bash_kernel/display.py
@@ -102,13 +102,13 @@ def display_data_for_image(filename):
     with open(filename, 'rb') as f:
         image = f.read()
     _unlink_if_temporary(filename)
-    image_type = filetype.image_match(image).extension
-    if image_type not in ("png", "jpg", "gif", "webp"):
+    image_type = filetype.image_match(image).mime
+    if image_type not in ("image/png", "image/jpg", "image/gif", "image/webp"):
         raise ValueError("Not a valid image: %s" % image)
 
     content = {
         'data': {
-            'image/' + image_type: image
+            image_type: image
         },
         'metadata': {}
     }

--- a/bash_kernel/display.py
+++ b/bash_kernel/display.py
@@ -103,7 +103,7 @@ def display_data_for_image(filename):
         image = f.read()
     _unlink_if_temporary(filename)
     image_type = filetype.image_match(image).extension
-    if image_type not in ("png", "jpeg", "gif", "webp"):
+    if image_type not in ("png", "jpg", "gif", "webp"):
         raise ValueError("Not a valid image: %s" % image)
 
     content = {

--- a/bash_kernel/display.py
+++ b/bash_kernel/display.py
@@ -103,13 +103,12 @@ def display_data_for_image(filename):
         image = f.read()
     _unlink_if_temporary(filename)
     image_type = filetype.image_match(image).extension
-    if image_type is None:
+    if image_type not in ("png", "jpeg", "gif", "webp"):
         raise ValueError("Not a valid image: %s" % image)
 
-    image_data = base64.b64encode(image).decode('ascii')
     content = {
         'data': {
-            'image/' + image_type: image_data
+            'image/' + image_type: image
         },
         'metadata': {}
     }

--- a/bash_kernel/display.py
+++ b/bash_kernel/display.py
@@ -52,10 +52,11 @@ display_data_for_<new_type>; (3) Create an entry in CONTENT_DATA_PREFIXES. Btw, 
 is your friend to debug the format of the content message.
 """
 import base64
-import imghdr
 import json
 import os
 import re
+
+import filetype
 
 
 _TEXT_SAVED_IMAGE = "bash_kernel: saved image data to: "
@@ -101,8 +102,7 @@ def display_data_for_image(filename):
     with open(filename, 'rb') as f:
         image = f.read()
     _unlink_if_temporary(filename)
-
-    image_type = imghdr.what(None, image)
+    image_type = filetype.image_match(image).extension
     if image_type is None:
         raise ValueError("Not a valid image: %s" % image)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
 ]
 readme = "README.rst"
-dependencies = ["pexpect (>=4.0)", "ipykernel"]
+dependencies = ["pexpect (>=4.0)", "ipykernel", "filetype"]
 classifiers = [
     "Framework :: Jupyter",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Introduces third-party dependency `filetype`.

Closes #146.